### PR TITLE
Update Get-EdgeEnterpriseMSI.ps1

### DIFF
--- a/Other/Get-EdgeEnterpriseMSI.ps1
+++ b/Other/Get-EdgeEnterpriseMSI.ps1
@@ -39,8 +39,8 @@
   .\Get-EdgeEnterpriseMSI.ps1 -Channel Beta -Folder D:\SourceCode\PowerShell\Div -Force
 
 #>
+[CmdletBinding()]
 param(
-  [CmdletBinding()]
   [Parameter(Mandatory = $True, HelpMessage = 'Channel to download, Valid Options are: Dev, Beta, Stable, EdgeUpdate, Policy')]
   [ValidateSet('Dev', 'Beta', 'Stable', 'EdgeUpdate', 'Policy')]
   [string]$Channel,
@@ -182,7 +182,8 @@ if (Test-Path $Folder) {
           }
         }
         else {
-          throw "File already exists and user chose not to overwrite"
+          Write-Host "File already exists and user chose not to overwrite, exiting script." -ForegroundColor Red
+          exit
         }
       }
     }


### PR DESCRIPTION
Various improvements made.

Script now handles multiple files (e.g. MacOS Edge files)

Parameter validation

Error handling (replacing write-host -colour red + breaks with throws

Formatting improvements

URI validation

bumped version

Other changes